### PR TITLE
0.2.0

### DIFF
--- a/src/analysis/AnalysisContext.ts
+++ b/src/analysis/AnalysisContext.ts
@@ -1718,6 +1718,14 @@ export class AnalysisContext {
                 continue
             }
 
+            const valueTypes = this.finalizeTypes(
+                this.resolveTypes({ expression: value }),
+            )
+
+            if (valueTypes.size === 1 && valueTypes.has('function')) {
+                continue
+            }
+
             let types: Set<string> | undefined
             if (keyName) {
                 literalKeys.add(keyName)

--- a/src/analysis/AnalysisContext.ts
+++ b/src/analysis/AnalysisContext.ts
@@ -1,6 +1,6 @@
 import ast from 'luaparse'
 import { LuaScope } from '../scopes'
-import { getLuaFieldKey, readLuaStringLiteral } from '../helpers'
+import { getLuaFieldKey, isEmptyClass, readLuaStringLiteral } from '../helpers'
 import {
     AssignmentItem,
     FunctionDefinitionItem,
@@ -268,6 +268,17 @@ export class AnalysisContext {
                     )
 
                     const finalizedCls = finalized as AnalyzedClass
+
+                    // avoid writing unnecessary empty class annotations
+                    if (
+                        cls.definingModule &&
+                        cls.definingModule !== this.currentModule &&
+                        isEmptyClass(finalizedCls)
+                    ) {
+                        i++
+                        continue
+                    }
+
                     classes.push(finalizedCls)
 
                     let list = clsMap.get(finalized.name)

--- a/src/analysis/types.d.ts
+++ b/src/analysis/types.d.ts
@@ -294,6 +294,11 @@ export interface TableInfo {
     className?: string
 
     /**
+     * The name used for the original assignment of the table.
+     */
+    originalName?: string
+
+    /**
      * The ID of the class containing this table as a field.
      */
     containerId?: string

--- a/src/analysis/types.d.ts
+++ b/src/analysis/types.d.ts
@@ -294,6 +294,11 @@ export interface TableInfo {
     className?: string
 
     /**
+     * Flag for whether a class should be local.
+     */
+    isLocalClass?: boolean
+
+    /**
      * The name used for the original assignment of the table.
      */
     originalName?: string

--- a/src/annotation/Annotator.ts
+++ b/src/annotation/Annotator.ts
@@ -329,7 +329,12 @@ export class Annotator extends BaseAnnotator {
                 out.push(`${identName} = `)
 
                 if (cls.deriveName && base) {
-                    out.push(`${base}:derive("${cls.deriveName}")`)
+                    // multiple base classes from Rosetta → just write a table
+                    if (base.includes(',')) {
+                        out.push('{}')
+                    } else {
+                        out.push(`${base}:derive("${cls.deriveName}")`)
+                    }
                 } else if (cls.literalFields.length > 0) {
                     out.push('{')
 

--- a/src/annotation/types.d.ts
+++ b/src/annotation/types.d.ts
@@ -23,4 +23,9 @@ export interface AnnotateArgs extends BaseAnnotateArgs {
      * Whether ambiguous analyzed types are allowed.
      */
     ambiguity: boolean
+
+    /**
+     * Regular expression used to determine whether a class or table has no initializer.
+     */
+    helperPattern?: string
 }

--- a/src/base/BaseAnnotator.ts
+++ b/src/base/BaseAnnotator.ts
@@ -99,7 +99,12 @@ export class BaseAnnotator extends Base {
                     cls.fields = []
                     cls.literalFields = []
                     cls.setterFields = []
-                    cls.staticFields = []
+
+                    // include nested classes, throw away the rest
+                    cls.staticFields = cls.staticFields.filter(
+                        (x) => x.types.size === 1 && !x.expression,
+                    )
+
                     continue
                 }
 

--- a/src/helpers/analysis/index.ts
+++ b/src/helpers/analysis/index.ts
@@ -1,0 +1,1 @@
+export { isEmptyClass } from './is-empty-class'

--- a/src/helpers/analysis/is-empty-class.ts
+++ b/src/helpers/analysis/is-empty-class.ts
@@ -1,0 +1,18 @@
+import { AnalyzedClass } from '../../analysis'
+
+/**
+ * Checks whether an analyzed class has no associated information.
+ * @param cls
+ */
+export const isEmptyClass = (cls: AnalyzedClass): boolean => {
+    return (
+        cls.fields.length === 0 &&
+        cls.literalFields.length === 0 &&
+        cls.staticFields.length === 0 &&
+        cls.functions.length === 0 &&
+        cls.methods.length === 0 &&
+        cls.constructors.length === 0 &&
+        cls.functionConstructors.length === 0 &&
+        cls.overloads.length === 0
+    )
+}

--- a/src/helpers/annotation/get-rosetta-type-string.ts
+++ b/src/helpers/annotation/get-rosetta-type-string.ts
@@ -6,7 +6,9 @@ export const getRosettaTypeString = (
     type = (type ?? 'unknown').trim()
 
     if (optional || nullable) {
-        return type.includes('|') ? `(${type})?` : `${type}?`
+        return type.includes('|') || type.startsWith('fun(')
+            ? `(${type})?`
+            : `${type}?`
     }
 
     return type

--- a/src/helpers/annotation/get-type-string.ts
+++ b/src/helpers/annotation/get-type-string.ts
@@ -11,7 +11,9 @@ export const getTypeString = (
 
     const type = types.size > 0 ? [...types].join(' | ') : 'unknown'
     if (nullable) {
-        return type.includes('|') ? `(${type})?` : `${type}?`
+        return type.includes('|') || type.startsWith('fun(')
+            ? `(${type})?`
+            : `${type}?`
     }
 
     return type

--- a/src/helpers/convert-analyzed/convert-analyzed-class.ts
+++ b/src/helpers/convert-analyzed/convert-analyzed-class.ts
@@ -14,7 +14,9 @@ export const convertAnalyzedClass = (
 ): WritableRosettaClass => {
     const rosettaCls: WritableRosettaClass = {
         name: cls.name,
-        extends: cls.extends ?? mergeCls?.extends,
+        extends: mergeCls?.extends?.includes(',')
+            ? mergeCls.extends
+            : (cls.extends ?? mergeCls?.extends),
         deprecated: mergeCls?.deprecated,
         mutable: mergeCls?.mutable,
         local: cls.local ? true : undefined,

--- a/src/helpers/convert-analyzed/get-heuristic-types.ts
+++ b/src/helpers/convert-analyzed/get-heuristic-types.ts
@@ -64,6 +64,7 @@ export const getHeuristicTypes = (
             break
 
         case 'PLAYERNUM':
+        case 'PLAYERID':
             heuristicTypes.add('integer')
             break
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './analysis'
 export * from './annotation'
 export { arrayToRecord } from './array-to-record'
 export * from './convert-analyzed'

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,6 +248,10 @@ const updateRosettaCommand = (yargs: yargs.Argv) => {
             string: true,
             desc: 'List of file identifiers to treat as known files',
         })
+        .option('skip-pattern', {
+            type: 'string',
+            desc: 'Regular expression to use to determine whether a name should be ignored',
+        })
 
     addExcludeOptions(yargs)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,6 +190,10 @@ const annotateCommand = (yargs: yargs.Argv) => {
             implies: ['rosetta'],
             desc: 'Generate typestubs using only Rosetta data',
         })
+        .option('helper-pattern', {
+            type: 'string',
+            desc: 'Regular expression to use to determine whether a class or table should have no initializer table',
+        })
         .check((args: any) => {
             if (!args.inputDirectory && !args.rosettaOnly) {
                 throw new Error(

--- a/src/rosetta/RosettaGenerator.ts
+++ b/src/rosetta/RosettaGenerator.ts
@@ -16,12 +16,17 @@ import {
 export class RosettaGenerator extends BaseAnnotator {
     protected rosettaFormat: 'json' | 'yml'
     protected keepTypes: boolean
+    protected skipPattern: RegExp | undefined
 
     constructor(args: RosettaGenerateArgs) {
         super(args)
 
         this.keepTypes = args.keepTypes ?? false
         this.rosettaFormat = args.format ?? 'yml'
+
+        if (args.skipPattern) {
+            this.skipPattern = new RegExp(args.skipPattern)
+        }
     }
 
     generateRosetta(mod: AnalyzedModule): string {
@@ -130,7 +135,7 @@ export class RosettaGenerator extends BaseAnnotator {
             const suffix = this.rosettaFormat === 'json' ? '.json' : '.yml'
 
             for (const mod of modules) {
-                if (skipIds.has(mod.id)) {
+                if (skipIds.has(mod.id) || this.skipPattern?.test(mod.id)) {
                     continue
                 }
 

--- a/src/rosetta/types.d.ts
+++ b/src/rosetta/types.d.ts
@@ -128,6 +128,7 @@ export interface RosettaAlias {
 export interface RosettaGenerateArgs extends BaseAnnotateArgs {
     format?: 'json' | 'yml'
     keepTypes?: boolean
+    skipPattern?: string
 }
 
 export interface RosettaUpdateArgs extends RosettaGenerateArgs {


### PR DESCRIPTION
Notable changes:

- Added a flag for a regular expression to indicate ignored classes/tables/functions/fields during Rosetta update.
- Added a flag for a regular expression pattern that determines helper classes in Rosetta files (skips the initializer).
- Fixed a bug with return tracking of tail calls. Resolves #7.
- Improved naming for some generated classes. Resolves #8.
- Removed function literals from classes. Resolved #9.
  - Tables will still use function literals (e.g., `Point2D.meta`).
